### PR TITLE
Fixes broken link to sumstats_specification.md

### DIFF
--- a/usecases/gwas_demo.md
+++ b/usecases/gwas_demo.md
@@ -63,7 +63,7 @@ run1_CASE2.plink2.gz
 run2_PHENO.regenie.gz
 run2_PHENO2.regenie.gz
 ```
-Each file is merged across all chromosomes, and has a minimal set of columns (``SNP, CHR, BP, A1, A2, N, Z, BETA, SE, PVAL``), as described in the [specification](gwas/sumstats_specification.md).
+Each file is merged across all chromosomes, and has a minimal set of columns (``SNP, CHR, BP, A1, A2, N, Z, BETA, SE, PVAL``), as described in the [specification](../gwas/sumstats_specification.md).
 
 It is also supported to run GWAS on dosages stored in BGEN format, instead of using hard call phenotypes from plink's bed/bim/fam format.
 If you have genotypes formatted this way, the only change you need is to replace ``--bed-test`` with ``--bgen-test``,


### PR DESCRIPTION
Changes the relative link to `sumstats_specification.md` to be based on the parent directory instead of the current directory (which gave you a `404 Not found` before).