### PR TITLE
Move out enigma-cnv.sif , ipsychcnv.sif, tryggve_query.sif 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ If MD5 sum is not listed for a certain release then it means that the container 
 
 - MAGMA, LAVA and ldblock software is moved to https://github.com/comorment/magma.
   MAGMA reference files are also moved to this repository.
+- enigma-cnv.sif and enigma-cnv.sif is moved to https://github.com/comorment/iPsychCNV
+  enigma-cnv.sif is also available here: in https://github.com/ENIGMA-git/ENIGMA-CNV/tree/main/CNVCalling/containers
+- tryggve_query.sif  is moved to https://github.com/comorment/Tryggve_psych
 - ``matlabruntime.sif`` container is moved to https://github.com/comorment/matlabruntime. 
   pleioFDR reference files are also moved to this repository.
 

--- a/docs/r.md
+++ b/docs/r.md
@@ -19,7 +19,3 @@ singularity shell --home $PWD:/home $SIF/r.sif
 ```
 and then follow the official tutorial https://cnsgenomics.com/software/gsmr/ . 
 Note that ``gcta64`` tool is also include in ``r.sif`` container, as the tutorial depends on it.
-
-For LAVA, the example data is  (``https://github.com/josefin-werme/LAVA/tree/main/vignettes``) is availabel within ``$COMORMENT/containers/reference/example/lava`` folder. The folder also has a README file explaining how to trigger this analysis.
-The ``ldblock`` tool (https://github.com/cadeleeuw/lava-partitioning) is also included in ``r.sif`` container.
-

--- a/singularity/enigma-cnv.sif
+++ b/singularity/enigma-cnv.sif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a693802ac81f10f8580143e87d72647a064920affd277f9dab809aba54e68993
-size 930361344

--- a/singularity/ipsychcnv.sif
+++ b/singularity/ipsychcnv.sif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af46b77111649fa23724d33f7f2cba5e3c15340cc679e3faf03497c0fe161e45
-size 930361344

--- a/singularity/tryggve_query.sif
+++ b/singularity/tryggve_query.sif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05ae5af9a04ca9144ba5a73469cf8039470739a5b390a656003846cb695be36f
-size 997371904


### PR DESCRIPTION
Fixes #58 

Changes proposed in this pull request:
- enigma-cnv.sif and ipsychcnv.sif is moved to https://github.com/comorment/iPsychCNV
  enigma-cnv.sif is also available here: in https://github.com/ENIGMA-git/ENIGMA-CNV/tree/main/CNVCalling/containers
- tryggve_query.sif  is moved to https://github.com/comorment/Tryggve_psych
- remove LAVA-related lines in ``docs/r.md``  (those lines were already included in https://github.com/comorment/magma/blob/main/README.md )

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
