### PR TITLE
Deepchocolate/ldpred2 updates fixes

### DIFF
--- a/usecases/LDpred2/README.md
+++ b/usecases/LDpred2/README.md
@@ -3,14 +3,14 @@
 The files in this directory exemplifies how to run the LDpred2 analysis using the ``bigsnpr`` R library, using [ldpred2.R](ldpred2.R) script developed by Andreas Jangmo, Espen Hagen and Oleksandr Frei. The script is based on this [tutorial](https://privefl.github.io/bigsnpr/articles/LDpred2.html).
 The LDpred2 method is explained in the publication:
 
-- Florian Privé, Julyan Arbel, Bjarni J Vilhjálmsson, LDpred2: better, faster, stronger, Bioinformatics, Volume 36, Issue 22-23, 1 December 2020, Pages 5424–5431, https://doi.org/10.1093/bioinformatics/btaa1029
+- Florian Privé, Julyan Arbel, Bjarni J Vilhjálmsson, LDpred2: better, faster, stronger, Bioinformatics, Volume 36, Issue 22-23, 1 December 2020, Pages 5424–5431, <https://doi.org/10.1093/bioinformatics/btaa1029>
 
 ## Prerequisites
 
-This README assumes the following two repositories are git cloned.
+This README assumes the following two repositories are cloned using [git](https://git-scm.com):
 
-* http://github.com/comorment/containers
-* https://github.com/comorment/ldpred2_ref
+- <http://github.com/comorment/containers>
+- <https://github.com/comorment/ldpred2_ref>
 
 We also assume the following commands are executed from the current folder
 (the one containing [createBackingFile.R](createBackingFile.R) and [ldpred2.R](ldpred2.R) scripts).
@@ -18,15 +18,16 @@ We also assume the following commands are executed from the current folder
 ### Optional: Estimating linkage disequillibrium (LD)
 
 LDpred2 uses the LD structure when calculating polygenic scores. By default, the LDpred2.R script uses LD structure based on European samples provided by the LDpred2 authors.
-To instead calculate LD on your own, the ``calculateLD.R`` script can be used. The output from this script can then be used as input to ``LDpred2.R``.
+To instead calculate LD on your own, the ``calculateLD.R`` script can be used. The output from this script can then be used as input to ``LDpred2.R`` (with the optional ``--ld-file`` flag).
 
-To use, ``calculateLD.R``, you need to download genetic maps from [1000 genomes](https://github.com/joepickrell/1000-genomes-genetic-maps) to convert each SNPs physical position to genomic position.
+To use ``calculateLD.R`` you need to download genetic maps from [1000 genomes](https://github.com/joepickrell/1000-genomes-genetic-maps) in order to convert each SNPs physical position to genomic position.
 If you don't provide these files, LDpred2 will try to download these automatically which will cause an error without an internet connection. To prevent this behavior, these should be downloaded manually and
 the folder where they are stored should be passed to the LDpred2-script using the flag ``--dir-genetic-maps your-genetic/maps-directory``.
 
 The example script below will output one file per chromosome (``output/ld-chr-1.rds``, ``output/ld-chr-2.rds``, ...) and a "map" indicating the SNPs used in LD estimation (``output/map.rds``).
 The flag ``--sumstats`` can be used to filter SNPs to use where the first argument is the file and the second the column name or position of the RSID of the SNP (ie it does not neeed to be a proper
 sumstats file).
+
 ```
 # point to input/output files
 export fileGeno=/REF/examples/ldpred2/g1000_eur_chr21to22_hm3rnd1.bed
@@ -56,7 +57,6 @@ $RSCRIPT calculateLD.R --geno-file-rds $fileGenoRDS \
  --chr2use 21 22  --sumstats $fileSumstats SNP \
  --file-ld-blocks $fileOutLD --file-ld-map $fileOutLDMap
 ```
- 
 
 ## Running LDpred2 analysis - synthetic example (chr21 and chr22)
 
@@ -94,6 +94,7 @@ $RSCRIPT ldpred2.R --ldpred-mode inf \
  --sumstats $fileSumstats \
  --out $fileOut.inf
  
+# run LDpred2 automatic mode
 $RSCRIPT ldpred2.R --ldpred-mode auto \
  --chr2use 21 22 \
  --file-pheno $filePheno \
@@ -106,6 +107,7 @@ $RSCRIPT ldpred2.R --ldpred-mode auto \
 ## Running LDpred2 analysis - height example
 
 The following set of commands gives an example of how to apply LDpred2 on a demo height data:
+
 ```
 # point to input/output files
 export fileGeno=/REF/examples/prsice2/EUR.bed
@@ -155,8 +157,9 @@ $RSCRIPT ldpred2.R \
 
 ## Output
 
-The main LDpred2 output files are ``Height.score.inf`` and ``Height.score.auto`` put in this directory. 
-The files are text files with tables formatted as 
+The main LDpred2 output files are ``Height.score.inf`` and ``Height.score.auto`` put in this directory.
+The files are text files with tables formatted as
+
 ```
 FID IID Height score
 HG00096 HG00096 169.132168767547 -0.733896062346436
@@ -170,9 +173,9 @@ The script will also output ``.bk`` and ``.rds`` binary files with prefix ``EUR`
 
 ## Handling missing genotypes
 
-By default LDpred2.R script will impute missing genotypes bigsnpr's ``mean0`` method from [snp_fastImputeSimple](https://www.rdocumentation.org/packages/bigsnpr/versions/1.6.1/topics/snp_fastImputeSimple).
+By default the LDpred2.R script will impute missing genotypes bigsnpr's ``mean0`` method from [snp_fastImputeSimple](https://www.rdocumentation.org/packages/bigsnpr/versions/1.6.1/topics/snp_fastImputeSimple).
 This is done because otherwise bigsnpr returns an error (``Error: You can't have missing values in 'X'.``).
-Imputing missing values, however, can be very slow, and eventually we want to include this in ``createBackingFile.R`` step, so this is done once, rather then as part of every ``LDpred2.R`` invocation.
+Imputing missing values, however, can be very slow, and eventually we [want](https://github.com/comorment/containers/pull/117#issuecomment-1409985505) to include this in ``createBackingFile.R`` step, so this is done once, rather then as part of every ``LDpred2.R`` invocation.
 
 For now, as a workaround, you may fall back to plink's ``fill-missing-a2`` option, then
 re-run ``createBackingFile.R``, and include ``--geno-impute skip`` in your ``LDpred2.R`` command:
@@ -184,17 +187,17 @@ $RSCRIPT createBackingFile.R EUR.nomiss.bed EUR.nomiss.rds
 $RSCRIPT ldpred2.R --geno-file-rds EUR.nomiss.rds --geno-impute skip ...
 ```
 
-
-
 ## Slurm job
 
 On an HPC resource the same analysis can be run by first writing a job script [run_ldpred2_slurm.job](run_ldpred2_slurm.job).
 In order to run the job, first make sure that the ``SBATCH_ACCOUNT`` environment variable is defined:
+
 ```
 export SBATCH_ACCOUNT=project_ID
 ```
-where ``project_ID`` is the granted project that compute time is allocated. 
-As above, ``<path/to/containers`` should point to the cloned ``containers`` repository. 
+
+where ``project_ID`` is the granted project that compute time is allocated.
+As above, ``<path/to/containers`` should point to the cloned ``containers`` repository.
 Entries like ``--partition=normal`` may also be adapted for different HPC resources.
-Then, the job can be submitted to the queue by issuing ``sbatch run_ldpred2_slurm.job``. 
-The status of running jobs can usually be enquired by issuing ``squeue -u $USER``. 
+Then, the job can be submitted to the queue by issuing ``sbatch run_ldpred2_slurm.job``.
+The status of running jobs can usually be enquired by issuing ``squeue -u $USER``.

--- a/usecases/LDpred2/README.md
+++ b/usecases/LDpred2/README.md
@@ -159,10 +159,10 @@ The main LDpred2 output files are ``Height.score.inf`` and ``Height.score.auto``
 The files are text files with tables formatted as 
 ```
 FID IID Height score
-HG00096 HG00096 169.132168767547 -1.49668824138468e+100
-HG00097 HG00097 171.256258630279 -3.37195056659838e+99
-HG00099 HG00099 171.534379938588 -5.02262306623802e+100
-HG00100 HG00100 NA -1.8332542097235e+100
+HG00096 HG00096 169.132168767547 -0.733896062346436
+HG00097 HG00097 171.256258630279 0.688693127521599
+HG00099 HG00099 171.534379938588 0.203279440703434
+HG00100 HG00100 NA 0.0890499485064315
 ...
 ```
 
@@ -178,9 +178,10 @@ For now, as a workaround, you may fall back to plink's ``fill-missing-a2`` optio
 re-run ``createBackingFile.R``, and include ``--geno-impute skip`` in your ``LDpred2.R`` command:
 
 ```
-plink --bfile EUR --fill-missing-a2 --make-bed --out EUR.nomiss
+export PLINK="singularity exec --home=$PWD:/home $SIF/gwas.sif plink"
+$PLINK --bfile /REF/examples/prsice2/EUR --fill-missing-a2 --make-bed --out EUR.nomiss
 $RSCRIPT createBackingFile.R EUR.nomiss.bed EUR.nomiss.rds
-$RSCRIPT ldpred2.R --geno-file EUR.nomiss.rds --geno-impute skip ...
+$RSCRIPT ldpred2.R --geno-file-rds EUR.nomiss.rds --geno-impute skip ...
 ```
 
 

--- a/usecases/LDpred2/README.md
+++ b/usecases/LDpred2/README.md
@@ -49,12 +49,14 @@ export RSCRIPT="singularity exec --home=$PWD:/home $SIF/r.sif Rscript"
 # convert genotype to LDpred2 format
 $RSCRIPT createBackingFile.R $fileGeno $fileGenoRDS
 
+# create genetics maps directory, download and process
+mkdir -p 100genomes/maps
 $RSCRIPT calculateLD.R --geno-file-rds $fileGenoRDS \
  --dir-genetic-maps 100genomes/maps \
  --chr2use 21 22  --sumstats $fileSumstats SNP \
  --file-ld-blocks $fileOutLD --file-ld-map $fileOutLDMap
 ```
-
+ 
 
 ## Running LDpred2 analysis - synthetic example (chr21 and chr22)
 
@@ -83,13 +85,22 @@ export RSCRIPT="singularity exec --home=$PWD:/home $SIF/r.sif Rscript"
 # convert genotype to LDpred2 format
 $RSCRIPT createBackingFile.R $fileGeno $fileGenoRDS
 
+# run LDpred2 infinitesimal mode
 $RSCRIPT ldpred2.R --ldpred-mode inf \
- --chr2use 21 22 --file-pheno $filePheno --col-pheno $colPheno \
- --geno-file $fileGenoRDS --sumstats $fileSumstats --out $fileOut.inf
-
+ --chr2use 21 22 \
+ --file-pheno $filePheno \
+ --col-pheno $colPheno \
+ --geno-file-rds $fileGenoRDS \
+ --sumstats $fileSumstats \
+ --out $fileOut.inf
+ 
 $RSCRIPT ldpred2.R --ldpred-mode auto \
- --chr2use 21 22 --file-pheno $filePheno --col-pheno $colPheno  \
- --geno-file $fileGenoRDS --sumstats $fileSumstats --out $fileOut.auto
+ --chr2use 21 22 \
+ --file-pheno $filePheno \
+ --col-pheno $colPheno  \
+ --geno-file-rds $fileGenoRDS \
+ --sumstats $fileSumstats \
+ --out $fileOut.auto
 ```
 
 ## Running LDpred2 analysis - height example
@@ -120,16 +131,26 @@ $RSCRIPT createBackingFile.R $fileGeno $fileGenoRDS
 # Generate PGS usign LDPRED-inf
 $RSCRIPT ldpred2.R \
  --ldpred-mode inf \
- --file-pheno $filePheno --col-pheno $colPheno \
- --col-stat OR --col-stat-se SE --stat-type OR \
- --geno-file $fileGenoRDS --sumstats $fileSumstats --out $fileOut.inf
+ --file-pheno $filePheno \
+ --col-pheno $colPheno \
+ --col-stat OR \
+ --col-stat-se SE \
+ --stat-type OR \
+ --geno-file-rds $fileGenoRDS \
+ --sumstats $fileSumstats \
+ --out $fileOut.inf
 
 # Generate PGS using LDPRED2-auto
 $RSCRIPT ldpred2.R \
  --ldpred-mode auto \
- --file-pheno $filePheno --col-pheno $colPheno \
- --col-stat OR --col-stat-se SE --stat-type OR \
- --geno-file $fileGenoRDS --sumstats $fileSumstats --out $fileOut.auto
+ --file-pheno $filePheno \
+ --col-pheno $colPheno \
+ --col-stat OR \
+ --col-stat-se SE \
+ --stat-type OR \
+ --geno-file-rds $fileGenoRDS \
+ --sumstats $fileSumstats \
+ --out $fileOut.auto
 ```
 
 ## Output

--- a/usecases/LDpred2/calculateLD.R
+++ b/usecases/LDpred2/calculateLD.R
@@ -19,6 +19,7 @@ par <- add_argument(par, "--sample-individuals", nargs=1, help="Specify a number
 par <- add_argument(par, "--chr2use", nargs=Inf, help="List of chromosomes to use (by default it uses chromosomes 1 to 22)")
 par <- add_argument(par, "--file-keep-snps", help="File with RSIDs of SNPs to keep")
 par <- add_argument(par, "--sumstats", nargs=2, help="Input file with GWAS summary statistics. First argument is the file, second is RSID column position (integer) or name.")
+par <- add_argument(par, "--sumstats-sep", default="", help="Field separator for GWAS summary statistics file (cf. utils::read.table)")
 par <- add_argument(par, "--window-size", default=3, nargs=1, help="Window size in centimorgans, used for LD calculation")
 par <- add_argument(par, "--cores", default=nb_cores(), nargs=1, help="Specify the number of processor cores to use, otherwise use the available - 1")
 
@@ -30,6 +31,7 @@ fileKeepSNPs <- parsed$file_keep_snps
 # Sumstats file
 fileSumstats <- parsed$sumstats[1]
 columnRsidSumstats <- parsed$sumstats[2]
+sepSumstats <- parsed$sumstats_sep
 # Sample individuals
 sampleIndividuals <- parsed$sample_individuals
 # Chromosomes to use
@@ -71,9 +73,9 @@ if (!is.na(fileKeepSNPs)) {
 }
 if (!is.na(fileSumstats)) {
   cat('Reading SNPs from sumstat file --sumstats:', fileSumstats, '\n')
-  fileSumstats <- read.table(fileSumstats, header=T, sep=',')
-  cat('Read', nrow(fileSumstats), 'SNPs\n')
-  SNPs <- SNPs[SNPs %in% fileSumstats[,columnRsidSumstats]]
+  dfSumStats <- read.table(fileSumstats, header=T, sep=sepSumstats)
+  cat('Read', nrow(dfSumStats), 'SNPs\n')
+  SNPs <- SNPs[SNPs %in% dfSumStats[,columnRsidSumstats]]
 }
 useSNPs <- MAP$rsid %in% SNPs
 cat('A total of', sum(useSNPs), 'will be used for LD calculation\n')

--- a/usecases/LDpred2/run_ldpred2_slurm.job
+++ b/usecases/LDpred2/run_ldpred2_slurm.job
@@ -37,14 +37,23 @@ $RSCRIPT createBackingFile.R $fileGeno $fileGenoRDS
 # Generate PGS usign LDPRED-inf
 $RSCRIPT ldpred2.R \
  --ldpred-mode inf \
- --file-pheno $filePheno --col-pheno $colPheno \
- --col-stat OR --col-stat-se SE --stat-type OR \
- --geno-file $fileGenoRDS --sumstats $fileSumstats --out $fileOut.inf
+ --file-pheno $filePheno \
+ --col-pheno $colPheno \
+ --col-stat OR \
+ --col-stat-se SE --stat-type OR \
+ --geno-file-rds $fileGenoRDS \
+ --sumstats $fileSumstats \
+ --out $fileOut.inf
 
 # Generate PGS using LDPRED2-auto
 $RSCRIPT ldpred2.R \
  --ldpred-mode auto \
- --file-pheno $filePheno --col-pheno $colPheno \
- --col-stat OR --col-stat-se SE --stat-type OR \
- --geno-file $fileGenoRDS --sumstats $fileSumstats --out $fileOut.auto
+ --file-pheno $filePheno \
+ --col-pheno $colPheno \
+ --col-stat OR \
+ --col-stat-se SE \
+ --stat-type OR \
+ --geno-file-rds $fileGenoRDS \
+ --sumstats $fileSumstats \
+ --out $fileOut.auto
 

--- a/usecases/LDpred2_example/README.md
+++ b/usecases/LDpred2_example/README.md
@@ -1,17 +1,18 @@
 # LDpred2 example
 
-Example running LDpred2 
-(Privé et al., Bioinformatics, Volume 36, Issue 22-23, 1 December 2020, Pages 5424–5431, https://doi.org/10.1093/bioinformatics/btaa1029) 
-for deriving polygenic scores based on summary statistics and a matrix of correlation between genetic variants. 
+Example running LDpred2
+(Privé et al., Bioinformatics, Volume 36, Issue 22-23, 1 December 2020, Pages 5424–5431, <https://doi.org/10.1093/bioinformatics/btaa1029>)
+for deriving polygenic scores based on summary statistics and a matrix of correlation between genetic variants.
 
 To run the example, issue in a terminal
+
 ```
 bash run.sh
 ```
 
-For indepth explanations of the example codes, cf. the [LDpred2 tutorial](https://privefl.github.io/bigsnpr/articles/LDpred2.html). 
+For indepth explanations of the example codes, cf. the [LDpred2 tutorial](https://privefl.github.io/bigsnpr/articles/LDpred2.html).
 
-The main purpose of the `run.sh` shell script is for testing the functionality of the [`LDpred2.R` script](https://github.com/comorment/containers/blob/main/usecases/LDpred2/ldpred2.R), 
+The main purpose of the `run.sh` shell script is for testing the functionality of the [`LDpred2.R` script](https://github.com/comorment/containers/blob/main/usecases/LDpred2/ldpred2.R),
 but may be set up for other datasets.
 
-Changing the line `LDPRED_MODES="inf"` to `LDPRED_MODES="auto"` allows running the LDpred2 analysis in "automatic" mode. 
+Changing the line `LDPRED_MODES="inf"` to `LDPRED_MODES="auto"` allows running the LDpred2 analysis in "automatic" mode.

--- a/usecases/LDpred2_example/run.sh
+++ b/usecases/LDpred2_example/run.sh
@@ -72,7 +72,7 @@ echo "TEST error: Bad imputation mode"
 dump=$( { $LDP --ldpred-mode inf --geno-impute bad-mode; } 2>&1 )
 if [ $? -eq 0 ]; then echo "No error received"; exit; fi
 
-## TEST: Complete runs of --ldpred-mode given by $LDPRED_MODES
+# TEST: Complete runs of --ldpred-mode given by $LDPRED_MODES
 for MODE in $LDPRED_MODES; do
  echo "Testing mode $MODE"
  dump=$( { $LDP --ldpred-mode $MODE; } 2>&1 )
@@ -90,7 +90,7 @@ LDE="$RSCRIPT $DIR_SCRIPTS/calculateLD.R --geno-file-rds $fileOutputSNPR \
 echo "Test restricting on a subset of SNPs (only chromosome 1-9 will run)"
 fileSumstats25k=$DIR_TESTS/data/public-data-sumstats25k.txt
 head -n 25000 $fileInputSumStats > $fileSumstats25k
-dump=$( { $LDE --sumstats $fileSumstats25k rsid; } 2>&1 )
+dump=$( { $LDE --sumstats $fileSumstats25k rsid --sumstats-sep ","; } 2>&1 )
 if [ $? -eq 1 ]; then echo "$dump"; exit; fi
 
 echo "Test restricting on SNPs provide by a SNP list file: $fileKeepSNPS"


### PR DESCRIPTION
Hi @deepchocolate. Just some minor fixes and readme updates to PR #117. 
The main change is a flag for the field separator in the sumstats file in the calculateLD.R script. 
I chose whitespace-separated, but don't know if this is the best choice, as the [sumstats_specification](https://github.com/comorment/containers/blob/main/gwas/sumstats_specification.md) doesn't mention what to expect. 
`read.table` doesn't automatically choose a suitable separator. 

Could run the README's height example(s) on the nrec devbox due to memory constraints, but assume all is well.