### PR TITLE
clarify `--geno-file-rds` arg

### DIFF
--- a/usecases/LDpred2/ldpred2.R
+++ b/usecases/LDpred2/ldpred2.R
@@ -15,7 +15,7 @@ source(paste0(dirScript, '/fun.R'))
 
 par <- arg_parser('Calculate polygenic scores using ldpred2')
 # Mandatory arguments (files)
-par <- add_argument(par, "--geno-file-rds", help="Input .rds (bigSNPR) file with genotypes")
+par <- add_argument(par, "--geno-file-rds", help="Input .rds (bigSNPR) file with genotypes. A similarly named .bk (backing) file must exist in the same location")
 par <- add_argument(par, "--sumstats", help="Input file with GWAS summary statistics")
 par <- add_argument(par, "--out", help="Output file with calculated PGS")
 


### PR DESCRIPTION
Minifix. The .bk backing file which must exist in parallel to the .rds file as created by the `createBackingFile.R` script is not explicitly referenced.

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Clarify `--geno-file-rds` arg by referencing the .bk file.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
