### PR TITLE
Fix LDpred2 error with uppercase chromosome column header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ If MD5 sum is not listed for a certain release then it means that the container 
 
 ### Fixed
 
-* Fixed issue with character encoding in with uppercase chromosome column name in sumstats files. 
+* Fixed issue with character encoding in sumstats files, in case chromosome column name is uppercase. 
 
 ## [1.3.0] - 2023-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ If MD5 sum is not listed for a certain release then it means that the container 
 
 * Miscellaneous goes here
 
-## [1.3.1] - 2023-06-05
+## [1.3.1] - 2023-06-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ If MD5 sum is not listed for a certain release then it means that the container 
 
 * Miscellaneous goes here
 
+## [1.3.1] - 2023-06-05
+
+### Added
+
+* Added unittest for uppercase chromosome column name in sumstats files, that may also contain chromosomes encoded as character(s)
+
+### Fixed
+
+* Fixed issue with character encoding in with uppercase chromosome column name in sumstats files. 
+
 ## [1.3.0] - 2023-05-19
 
 ### Added

--- a/scripts/pgs/LDpred2/ldpred2.R
+++ b/scripts/pgs/LDpred2/ldpred2.R
@@ -177,11 +177,11 @@ sumstats$a1 <- toupper(sumstats$a1)
 # Check that there are no characters in chromosome column (causes snp_match to fail)
 if (!isOnlyNumeric(sumstats$chr)) {
   cat('Removing rows with non-integers in column', colChr, '\n')
-  numeric <- getNumericIndices(sumstats[, colChr])
+  numeric <- getNumericIndices(sumstats$chr)
   cat('Removing', nrow(sumstats) - length(numeric), 'SNPs...\n')
   sumstats <- sumstats[numeric,]
   cat('Retained', nrow(sumstats), 'SNPs\n')
-  sumstats[, colChr] <- as.numeric(sumstats[, colChr])
+  sumstats$chr <- as.numeric(sumstats$chr)
 }
 
 ### Determine effective sample-size

--- a/tests/test_LDpred2/scripts/extended.sh
+++ b/tests/test_LDpred2/scripts/extended.sh
@@ -14,12 +14,19 @@ echo "$row" >> $fileSumstatsWithChar
 dump=$( { $LDP --ldpred-mode inf --col-chr chr --geno-file-rds $fileImputed.rds --sumstats $fileSumstatsWithChar; } 2>&1 )
 if [ $? -eq 1 ]; then echo "$dump"; exit; fi
 
+echo "Test error: upper case CHR column in sumstats file"
+sed -i '1s/chr/CHR/' $fileSumstatsWithChar
+dump=$( { $LDP --ldpred-mode inf --col-chr CHR --geno-file-rds $fileImputed.rds --sumstats $fileSumstatsWithChar; } 2>&1 )
+if [ $? -eq 1 ]; then echo "$dump"; exit; fi
+
 echo "Test error: Missing genotypes"
 dump=$( { $LDP --ldpred-mode inf --col-chr chr --geno-file-rds $fileImpute.rds --sumstats $fileInputSumStats; } 2>&1 )
 if [ $? -eq 0 ]; then echo "No error received"; echo "$dump"; exit; fi
+
 echo "Test --geno-impute-zero"
 dump=$( { $LDP --ldpred-mode inf --col-chr chr --geno-file-rds $fileImpute.rds --geno-impute-zero --sumstats $fileInputSumStats; } 2>&1 )
 if [ $? -eq 1 ]; then echo "$dump"; exit; fi
+
 echo "Test preimputed file"
 dump=$( { $LDP --ldpred-mode inf --col-chr chr --geno-file-rds $fileImputed.rds --sumstats $fileInputSumStats; } 2>&1 )
 if [ $? -eq 1 ]; then echo "$dump"; exit; fi

--- a/version/version.py
+++ b/version/version.py
@@ -2,7 +2,7 @@ _MAJOR = "1"
 _MINOR = "3"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "0"
+_PATCH = "1"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #179 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds test and fix of LDpred2 crash occurring if sumstats column header is uppercase (e.g., `CHR`), and column also encodes chromosomes using characters (e.g., `X`)

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
