### PR TITLE
LDpred2: Build 37/38 behavior/documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ If MD5 sum is not listed for a certain release then it means that the container 
 ### Misc
 
 * Miscellaneous goes here
+## [1.3.7] - 2023-10-11
+
+### Fixed
+
+* Added `--genomic-build hg18/hg19/hg38` option to `ldpred2.R` to use correct LD reference meta file ``pos`` column name
 
 ## [1.3.6] - 2023-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ If MD5 sum is not listed for a certain release then it means that the container 
 ### Misc
 
 * Miscellaneous goes here
-## [1.3.7] - 2023-10-11
+## [1.3.8] - 2023-10-17
 
 ### Fixed
 

--- a/scripts/pgs/LDpred2/README.md
+++ b/scripts/pgs/LDpred2/README.md
@@ -31,19 +31,19 @@ yielding:
 
 ```
 usage: ldpred2.R [--] [--help] [--out-merge] [--geno-impute-zero]
-       [--opts OPTS] [--geno-file-rds GENO-FILE-RDS] [--sumstats
-       SUMSTATS] [--out OUT] [--out-merge-ids OUT-MERGE-IDS]
-       [--file-keep-snps FILE-KEEP-SNPS] [--ld-file LD-FILE]
-       [--ld-meta-file LD-META-FILE] [--chr2use CHR2USE] [--col-chr
-       COL-CHR] [--col-snp-id COL-SNP-ID] [--col-A1 COL-A1] [--col-A2
-       COL-A2] [--col-bp COL-BP] [--col-stat COL-STAT] [--col-stat-se
-       COL-STAT-SE] [--col-pvalue COL-PVALUE] [--col-n COL-N]
-       [--stat-type STAT-TYPE] [--effective-sample-size
+       [--merge-by-rsid] [--opts OPTS] [--geno-file-rds GENO-FILE-RDS]
+       [--sumstats SUMSTATS] [--out OUT] [--out-merge-ids
+       OUT-MERGE-IDS] [--file-keep-snps FILE-KEEP-SNPS] [--ld-file
+       LD-FILE] [--ld-meta-file LD-META-FILE] [--chr2use CHR2USE]
+       [--col-chr COL-CHR] [--col-snp-id COL-SNP-ID] [--col-A1 COL-A1]
+       [--col-A2 COL-A2] [--col-bp COL-BP] [--col-stat COL-STAT]
+       [--col-stat-se COL-STAT-SE] [--col-pvalue COL-PVALUE] [--col-n
+       COL-N] [--stat-type STAT-TYPE] [--effective-sample-size
        EFFECTIVE-SAMPLE-SIZE] [--n-cases N-CASES] [--n-controls
        N-CONTROLS] [--name-score NAME-SCORE] [--hyper-p-length
        HYPER-P-LENGTH] [--hyper-p-max HYPER-P-MAX] [--ldpred-mode
        LDPRED-MODE] [--cores CORES] [--set-seed SET-SEED]
-       [--merge-by-rsid MERGE-BY-RSID]
+       [--genomic-build GENOMIC-BUILD]
 
 Calculate polygenic scores using ldpred2
 
@@ -88,6 +88,15 @@ $PLINK --bfile /REF/examples/prsice2/EUR --fill-missing-a2 --make-bed --out EUR.
 $RSCRIPT createBackingFile.R EUR.nomiss.bed EUR.nomiss.rds
 $RSCRIPT ldpred2.R --geno-file-rds EUR.nomiss.rds ...
 ```
+
+### Note on genomic builds
+
+By default the LDpred2 scripts assume that the genotype data and summary statistics use build GRCh37/hg19, 
+but there are no explicit checks for consistent builds across input files.
+If the genotype data and summary statistics file use another build, the ``--genomic-build <build>`` flag should be used to specify build version,
+parsing either `hg18`, `hg19` or `hg38` as argument.
+As of now, setting this argument will affect the loading of LD metadata only, but not the genotype data or summary statistics.
+A symptom of using the wrong build is that the script will match only a small fraction of variants between the genotype data, summary statistics file and/or LD reference data.
 
 ### Optional: Estimating linkage disequillibrium (LD)
 

--- a/scripts/pgs/LDpred2/ldpred2.R
+++ b/scripts/pgs/LDpred2/ldpred2.R
@@ -154,7 +154,7 @@ cat('\n### Reading LD reference meta-file from ', fileMetaLD, '\n')
 map_ldref <- readRDS(fileMetaLD)
 
 # rename pos column in map_ldref if another genomic build is assumed:
-if (parsed$genomic_build != 'hg19') {
+if (!parsed$genomic_build %in% c('hg18', 'hg19', 'hg38')) stop('Genomic build should be one of "hg19", "hg18", "hg38"') {
   if (parsed$genomic_build == 'hg_38') {
     cat('Renaming "pos_hg38" column in LD reference meta info as "pos"\n')
     map_ldref$pos <- map_ldref$pos_hg38
@@ -164,7 +164,8 @@ if (parsed$genomic_build != 'hg19') {
     map_ldref$pos <- map_ldref$pos_hg18
     map_ldref$pos_hg18 <- NULL
   } else {
-    stop('Genomic build should be one of "hg19", "hg18", "hg38"')}
+    # pass
+  }
 }
 
 cat('\n### Reading summary statistics', fileSumstats,'\n')

--- a/scripts/pgs/LDpred2/ldpred2.R
+++ b/scripts/pgs/LDpred2/ldpred2.R
@@ -154,19 +154,19 @@ cat('\n### Reading LD reference meta-file from ', fileMetaLD, '\n')
 map_ldref <- readRDS(fileMetaLD)
 
 # rename pos column in map_ldref if another genomic build is assumed:
-if (!parsed$genomic_build %in% c('hg18', 'hg19', 'hg38')) stop('Genomic build should be one of "hg19", "hg18", "hg38"') {
-  if (parsed$genomic_build == 'hg_38') {
-    cat('Renaming "pos_hg38" column in LD reference meta info as "pos"\n')
-    map_ldref$pos <- map_ldref$pos_hg38
-    map_ldref$pos_hg38 <- NULL
-  } else if (parsed$genomic_build == 'hg_18') {
-    cat('Renaming "pos_hg18" column in LD reference meta info as "pos"\n')
-    map_ldref$pos <- map_ldref$pos_hg18
-    map_ldref$pos_hg18 <- NULL
-  } else {
-    # pass
-  }
+if (!parsed$genomic_build %in% c('hg18', 'hg19', 'hg38')) stop('Genomic build should be one of "hg19", "hg18", "hg38"')
+if (parsed$genomic_build == 'hg_38') {
+  cat('Renaming "pos_hg38" column in LD reference meta info as "pos"\n')
+  map_ldref$pos <- map_ldref$pos_hg38
+  map_ldref$pos_hg38 <- NULL
+} else if (parsed$genomic_build == 'hg_18') {
+  cat('Renaming "pos_hg18" column in LD reference meta info as "pos"\n')
+  map_ldref$pos <- map_ldref$pos_hg18
+  map_ldref$pos_hg18 <- NULL
+} else {
+  # pass
 }
+
 
 cat('\n### Reading summary statistics', fileSumstats,'\n')
 sumstats <- bigreadr::fread2(fileSumstats)

--- a/scripts/pgs/LDpred2/ldpred2.R
+++ b/scripts/pgs/LDpred2/ldpred2.R
@@ -53,6 +53,7 @@ par <- add_argument(par, "--ldpred-mode", help='Ether "auto" or "inf" (infinites
 par <- add_argument(par, "--cores", help="Number of CPU cores to use, otherwise use the available number of cores minus 1", default=nb_cores())
 par <- add_argument(par, '--set-seed', help="Set a seed for reproducibility", nargs=1)
 par <- add_argument(par, "--merge-by-rsid", help="Merge using rsid (the default is to merge by chr:bp:a1:a2 codes).", flag=TRUE)
+par <- add_argument(par, "--genomic-build", help="Genomic build to use. Either hg19, hg18 or hg38", default="hg19", nargs=1)
 
 parsed <- parse_args(par)
 
@@ -151,6 +152,20 @@ if (genoImputeZero) {
 
 cat('\n### Reading LD reference meta-file from ', fileMetaLD, '\n')
 map_ldref <- readRDS(fileMetaLD)
+
+# rename pos column in map_ldref if another genomic build is assumed:
+if (parsed$genomic_build != 'hg19') {
+  if (parsed$genomic_build == 'hg_38') {
+    cat('Renaming "pos_hg38" column in LD reference meta info as "pos"\n')
+    map_ldref$pos <- map_ldref$pos_hg38
+    map_ldref$pos_hg38 <- NULL
+  } else if (parsed$genomic_build == 'hg_18') {
+    cat('Renaming "pos_hg18" column in LD reference meta info as "pos"\n')
+    map_ldref$pos <- map_ldref$pos_hg18
+    map_ldref$pos_hg18 <- NULL
+  } else {
+    stop('Genomic build should be one of "hg19", "hg18", "hg38"')}
+}
 
 cat('\n### Reading summary statistics', fileSumstats,'\n')
 sumstats <- bigreadr::fread2(fileSumstats)

--- a/version/version.py
+++ b/version/version.py
@@ -2,7 +2,7 @@ _MAJOR = "1"
 _MINOR = "3"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "7"
+_PATCH = "8"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""

--- a/version/version.py
+++ b/version/version.py
@@ -2,7 +2,7 @@ _MAJOR = "1"
 _MINOR = "3"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "6"
+_PATCH = "7"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #189

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Added `--genomic-build hg18/hg19/hg38` option to `ldpred2.R` in order to use correct `pos` column in `ldpred2_ref/map_hm3_plus.rds` file in case geno/sumstat files uses another build. 
- Added some explanation of the feature in the LDpred2 README file

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
