### PR TITLE
`LDpred2.R`: redirect temporary data during runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ If MD5 sum is not listed for a certain release then it means that the container 
 ### Misc
 
 * Miscellaneous goes here
+
+## [1.3.9] - 2023-10-17
+
+### Added
+
+* User-set directory option for temporary files during LDpred2 runs, by default `base::tempdir()`
+
 ## [1.3.8] - 2023-10-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ If MD5 sum is not listed for a certain release then it means that the container 
 
 * Miscellaneous goes here
 
+## [1.3.7] - 2023-10-12
+
+* User-set directory for temporary files during LDpred2 runs, by default `base::tempdir()`
+
 ## [1.3.6] - 2023-08-17
 
 ### Fixed

--- a/scripts/pgs/LDpred2/README.md
+++ b/scripts/pgs/LDpred2/README.md
@@ -31,19 +31,19 @@ yielding:
 
 ```
 usage: ldpred2.R [--] [--help] [--out-merge] [--geno-impute-zero]
-       [--opts OPTS] [--geno-file-rds GENO-FILE-RDS] [--sumstats
-       SUMSTATS] [--out OUT] [--out-merge-ids OUT-MERGE-IDS]
-       [--file-keep-snps FILE-KEEP-SNPS] [--ld-file LD-FILE]
-       [--ld-meta-file LD-META-FILE] [--chr2use CHR2USE] [--col-chr
-       COL-CHR] [--col-snp-id COL-SNP-ID] [--col-A1 COL-A1] [--col-A2
-       COL-A2] [--col-bp COL-BP] [--col-stat COL-STAT] [--col-stat-se
-       COL-STAT-SE] [--col-pvalue COL-PVALUE] [--col-n COL-N]
-       [--stat-type STAT-TYPE] [--effective-sample-size
+       [--merge-by-rsid] [--opts OPTS] [--geno-file-rds GENO-FILE-RDS]
+       [--sumstats SUMSTATS] [--out OUT] [--out-merge-ids
+       OUT-MERGE-IDS] [--file-keep-snps FILE-KEEP-SNPS] [--ld-file
+       LD-FILE] [--ld-meta-file LD-META-FILE] [--chr2use CHR2USE]
+       [--col-chr COL-CHR] [--col-snp-id COL-SNP-ID] [--col-A1 COL-A1]
+       [--col-A2 COL-A2] [--col-bp COL-BP] [--col-stat COL-STAT]
+       [--col-stat-se COL-STAT-SE] [--col-pvalue COL-PVALUE] [--col-n
+       COL-N] [--stat-type STAT-TYPE] [--effective-sample-size
        EFFECTIVE-SAMPLE-SIZE] [--n-cases N-CASES] [--n-controls
        N-CONTROLS] [--name-score NAME-SCORE] [--hyper-p-length
        HYPER-P-LENGTH] [--hyper-p-max HYPER-P-MAX] [--ldpred-mode
-       LDPRED-MODE] [--cores CORES] [--set-seed SET-SEED]
-       [--merge-by-rsid MERGE-BY-RSID]
+       LDPRED-MODE] [--cores CORES] [--set-seed SET-SEED] [--tmp-dir
+       TMP-DIR]
 
 Calculate polygenic scores using ldpred2
 
@@ -327,3 +327,20 @@ As above, ``<path/to/containers`` should point to the cloned ``containers`` repo
 Entries like ``--partition=normal`` may also be adapted for different HPC resources.
 Then, the job can be submitted to the queue by issuing ``sbatch run_ldpred2_slurm.job``.
 The status of running jobs can usually be enquired by issuing ``squeue -u $USER``.
+
+
+### Redirect temporary file output
+
+By default, the LDpred2.R script will put large file(s) in the system temporary directory (using `base::tempdir()`).
+For use on HPC resources, use of the designated `$SCRATCH`, `$LOCALTMP`, or `$TMPDIR` directories is recommended to avoid
+filling up the system temporary directory.
+
+One can redirect the temporary file output by setting the `TMPDIR` environment variable to a mounted directory on the HPC resource, 
+by incorporating the following lines to the job script:
+
+```
+export SINGULARITY_BIND=$REFERENCE:/REF,${LDPRED2_REF}:/ldpred2_ref,$SCRATCH:/scratch
+export SINGULARITYENV_TMPDIR=/scratch
+```
+
+Otherwise, the location of temporary files can be specified by the `--tmp-dir` argument to the `ldpred2.R` script.

--- a/scripts/pgs/LDpred2/ldpred2.R
+++ b/scripts/pgs/LDpred2/ldpred2.R
@@ -234,11 +234,8 @@ drops <- c("_NUM_ID_.ss", "rsid.ss", 'block_id', 'pos_hg18', 'pos_hg38')
 df_beta <- df_beta[ , !(names(df_beta) %in% drops)]  
 
 cat('\n### Loading LD reference from ', fileLD, '\n')
-if (file.exists(parsed$tmp_dir)) {
-  tmp_file <- tempfile(tmpdir=parsed$tmp_dir)
-} else {
-  stop("Temporary directory", parsed$tmp_dir, "does not exist or is not writable")
-}
+if (!file.exists(parsed$tmp_dir)) stop("Temporary directory", parsed$tmp_dir, "does not exist") 
+tmp_file <- tempfile(tmpdir=parsed$tmp_dir)
 ld_size <- 0; corr <- NULL
 for (chr in chr2use) {
   ## indices in 'df_beta' corresponding to a particular 'chr'

--- a/version/version.py
+++ b/version/version.py
@@ -2,7 +2,7 @@ _MAJOR = "1"
 _MINOR = "3"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "6"
+_PATCH = "7"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #203

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Add an option to redirect temporary data for `LDpred2.R` using `--tmp-dir` flag. By default using R's`base::tempdir()`

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
