### PR TITLE
`ldpred2.R`: fix `hg_38` should be `hg38` and `hg_18` should be `hg18`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ If MD5 sum is not listed for a certain release then it means that the container 
 
 * Miscellaneous goes here
 
+## [1.7.1] - 2024-02-06
+
+### Fixed
+
+* Fixed parsing of  `--genomic-build hg18/hg38` in `ldpred2.R`
+
 ## [1.7.0] - 2024-02-02
 
 ### Added

--- a/scripts/pgs/LDpred2/ldpred2.R
+++ b/scripts/pgs/LDpred2/ldpred2.R
@@ -159,11 +159,11 @@ map_ldref <- readRDS(fileMetaLD)
 
 # rename pos column in map_ldref if another genomic build is assumed:
 if (!parsed$genomic_build %in% c('hg18', 'hg19', 'hg38')) stop('Genomic build should be one of "hg19", "hg18", "hg38"')
-if (parsed$genomic_build == 'hg_38') {
+if (parsed$genomic_build == 'hg38') {
   cat('Renaming "pos_hg38" column in LD reference meta info as "pos"\n')
   map_ldref$pos <- map_ldref$pos_hg38
   map_ldref$pos_hg38 <- NULL
-} else if (parsed$genomic_build == 'hg_18') {
+} else if (parsed$genomic_build == 'hg18') {
   cat('Renaming "pos_hg18" column in LD reference meta info as "pos"\n')
   map_ldref$pos <- map_ldref$pos_hg18
   map_ldref$pos_hg18 <- NULL

--- a/version/version.py
+++ b/version/version.py
@@ -2,7 +2,7 @@ _MAJOR = "1"
 _MINOR = "7"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "0"
+_PATCH = "1"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""


### PR DESCRIPTION

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #223

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Fixed parsing of arguments to `--genomic-build` in `ldpred2.R`

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
