### PR TITLE
add support for additional options in gwas.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ If MD5 sum is not listed for a certain release then it means that the container 
 ### Added
 
 * Added options `--extract`, `--extract-step1`, `--extract-step2`, `--exclude`, `--exclude-step1`, and `--exclude-step2` to the `gwas.py` script to enable inclusion and exclusion of SNPs
+* Added support for additional customisations through `config.yaml` file for association analyses
 
 ### Updated
 

--- a/scripts/gwas/config.yaml
+++ b/scripts/gwas/config.yaml
@@ -16,5 +16,16 @@ comorment_folder: "/ess/p697/data/durable/s3-api/github/comorment"
 # SINGULARITY_BIND variable to set in SLURM scripts
 singularity_bind: "$COMORMENT/containers/reference:/REF:ro;/ess/p697:/ess/p697"
 
-saige:
-  cpus_per_task_stage2: 1
+# Additional options can be passed to GWAS analyses as in the below examples.
+# Value should be empty for flags.
+
+#regenie:
+#  step1:
+#    force-step1:
+#  step2:
+#    firth:
+#    approx:
+#    pThresh: 0.01
+
+#plink2:
+#  vif: 999

--- a/scripts/gwas/gwas.py
+++ b/scripts/gwas/gwas.py
@@ -344,7 +344,7 @@ def get_args_from_config(conf_obj, *args):
     def unpack(d, li):
         return unpack(d[li[0]], li[1:]) if len(li) != 0 else d
     try:
-        return " " + " ".join([f"--{k} {v}" if v is not None else f"--{k}" for k,v in unpack(conf_obj, args).items()])
+        return " " + " ".join([f"--{k} {v}" if v is not None else f"--{k}" for k, v in unpack(conf_obj, args).items()])
     except (KeyError, AttributeError):
         return ""
 

--- a/scripts/gwas/gwas.py
+++ b/scripts/gwas/gwas.py
@@ -340,6 +340,14 @@ def fix_and_validate_gwas_args(args, log):
     if ('regenie' in args.analysis) and (not args.geno_fit_file):
         raise ValueError('--geno-fit-file must be specified for --analysis regenie')
 
+def get_args_from_config(conf_obj, *args):
+    def unpack(d, li):
+        return unpack(d[li[0]], li[1:]) if len(li) != 0 else d
+    try:
+        return " " + " ".join([f"--{k} {v}" if v is not None else f"--{k}" for k,v in unpack(conf_obj, args).items()])
+    except (KeyError, AttributeError):
+        return ""
+
 def make_regenie_commands(args, logistic, step):
     geno_fit_file = args.geno_fit_file
     geno_file = args.geno_file.replace('@', '${SLURM_ARRAY_TASK_ID}')
@@ -376,7 +384,8 @@ def make_regenie_commands(args, logistic, step):
         (" --bt" if logistic else "") + \
         " --lowmem --lowmem-prefix {}_tmp_preds".format(args.out) + \
         (f" --exclude {args.exclude or args.exclude_step1}" if args.exclude or args.exclude_step1 else "") + \
-        (f" --extract {args.extract or args.extract_step1}" if args.extract or args.extract_step1 else "")
+        (f" --extract {args.extract or args.extract_step1}" if args.extract or args.extract_step1 else "") + \
+        get_args_from_config(args.config_object, 'regenie', 'step1')
 
     is_bed = is_bed_file(geno_file)
     is_pgen = is_pgen_file(geno_file)
@@ -390,7 +399,8 @@ def make_regenie_commands(args, logistic, step):
         " --pred {}.step1_pred.list".format(args.out) + \
         " --chr ${SLURM_ARRAY_TASK_ID}" + \
         (f" --exclude {args.exclude or args.exclude_step2}" if args.exclude or args.exclude_step2 else "") + \
-        (f" --extract {args.extract or args.extract_step2}" if args.extract or args.extract_step2 else "")
+        (f" --extract {args.extract or args.extract_step2}" if args.extract or args.extract_step2 else "") + \
+        get_args_from_config(args.config_object, 'regenie', 'step2')
 
     return (cmd + cmd_step1) if step == 1 else (cmd + cmd_step2)
 
@@ -460,7 +470,8 @@ def make_plink2_commands(args):
         (" --vcf {} --double-id".format(geno_file) if is_vcf_file(geno_file) else "") + \
         " --chr ${SLURM_ARRAY_TASK_ID}" + \
         (f" --exclude {args.exclude}" if args.exclude else "") + \
-        (f" --extract {args.extract}" if args.extract else "")
+        (f" --extract {args.extract}" if args.extract else "") + \
+        get_args_from_config(args.config_object, 'plink2')
     return cmd
 
 def make_plink2_glm_commands(args, logistic):


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #245 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- The dictionaries regenie:step1, regenie:step2 and plink2 in `config.yaml` are now used to pass commands created by `gwas.py`. For example, the snippet below can be added to the `config.yaml` file to include the `--force-step1` option in the step 1 of the `regenie` analysis.

```
regenie:
  step1:
    force-step1:
```

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/comorment/containers/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant documentation and docstrings where appropriate in the codebase.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
